### PR TITLE
Allowing PaletteTextInput

### DIFF
--- a/Pom.Controls.cs
+++ b/Pom.Controls.cs
@@ -462,7 +462,7 @@ public static partial class Pom
 		public ManagedStringControl(
 			ManagedFieldWithPanel field,
 			ManagedData data,
-			ManagedControlPanel panel,
+			DevUINode panel,
 			float sizeOfDisplayname)
 				: base(
 					  panel.owner,
@@ -514,6 +514,7 @@ public static partial class Pom
 				if ((subNodes[1] as RectangularDevUINode)!.MouseOver && activeStringControl != this)
 				{
 					// replace whatever instance/null that was focused
+					 Text = field.DisplayValueForNode(this, data);
 					activeStringControl = this;
 					subNodes[1].fLabels[0].color = new Color(0.1f, 0.4f, 0.2f);
 				}


### PR DESCRIPTION
Generalizes ManagedStringControl to be used by any DevUINode instead of only being used by ManagedControlPanels. This is critical for RegionKit's PaletteTextInput to function.