### PR TITLE
Add VectorList, VectorArray with controllable Node amount in Dev Tools

### DIFF
--- a/Mod.cs
+++ b/Mod.cs
@@ -25,6 +25,8 @@ namespace PomCore;
 /// to be "stackable" at runtime with multiple instances of POM
 /// in multiple mods. It is not recommended to do that anymore, but
 /// you still can if you really want to.
+///
+/// This fork is made to add additional features to POM, written by Cactus
 /// </summary>
 [BepInEx.BepInPlugin("rwmodding.coreorg.pom", "Pom", "3.0")]
 public class Mod : BepInEx.BaseUnityPlugin

--- a/Mod.cs
+++ b/Mod.cs
@@ -26,7 +26,7 @@ namespace PomCore;
 /// in multiple mods. It is not recommended to do that anymore, but
 /// you still can if you really want to.
 ///
-/// This fork is made to add additional features to POM, written by Cactus
+/// VectorList added by Cactus
 /// </summary>
 [BepInEx.BepInPlugin("rwmodding.coreorg.pom", "Pom", "3.0")]
 public class Mod : BepInEx.BaseUnityPlugin

--- a/Pom/Examples.cs
+++ b/Pom/Examples.cs
@@ -23,11 +23,12 @@ public static class Examples
 		[Vector2Field("vector", 10f, 30f)]
 		internal Vector2 Vec;
 		[IntVector2Field("intvector", 3, 3, IntVector2Field.IntVectorReprType.tile)]
-		internal IntVector2 IntVec;
+		internal IntVector2 IntVec;*/
 		[Vector2ArrayField("vectorarray", 5, false, Vector2ArrayField.Vector2ArrayRepresentationType.Chain, 10f, 10f, 20f, 20f, 20f, -20f, -20f, -20f, -20f, 20f)]
-		internal Vector2[] VecArray = new Vector2[0];*/
+		internal Vector2[] VecArray = new Vector2[0];
 		// TODO: Don't forget to uncomment all of this lmao
-		[Vector2ListField("vectorlist", 10, false, Vector2ListField.Vector2ListRepresentationType.Polygon)]
+		internal static Vector2[] evilList = new Vector2[4];
+		[Vector2ListField("vectorlist", 10, 3, false, Vector2ListField.Vector2ListRepresentationType.Polygon)]
 		internal Vector2[] VecList = new Vector2[0];
 		/*[EnumField<BepInEx.Logging.LogLevel>("enum", BepInEx.Logging.LogLevel.Warning)]
 		BepInEx.Logging.LogLevel Enum;

--- a/Pom/Examples.cs
+++ b/Pom/Examples.cs
@@ -12,7 +12,7 @@ public static class Examples
 {
 	internal class OneOfAll : ManagedData
 	{
-		/*[ColorField("color", 1, 1, 1, 1, ManagedFieldWithPanel.ControlType.button, "color")]
+		[ColorField("color", 1, 1, 1, 1, ManagedFieldWithPanel.ControlType.button, "color")]
 		internal Color color;
 		[IntegerField("int", 0, 10, 0)] // TODO: Implement IntegerField automatically within Vector2ListField?
 		internal int Int;
@@ -23,17 +23,15 @@ public static class Examples
 		[Vector2Field("vector", 10f, 30f)]
 		internal Vector2 Vec;
 		[IntVector2Field("intvector", 3, 3, IntVector2Field.IntVectorReprType.tile)]
-		internal IntVector2 IntVec;*/
+		internal IntVector2 IntVec;
 		[Vector2ArrayField("vectorarray", 5, false, Vector2ArrayField.Vector2ArrayRepresentationType.Chain, 10f, 10f, 20f, 20f, 20f, -20f, -20f, -20f, -20f, 20f)]
 		internal Vector2[] VecArray = new Vector2[0];
-		// TODO: Don't forget to uncomment all of this lmao
-		internal static Vector2[] evilList = new Vector2[4];
-		[Vector2ListField("vectorlist", 10, 3, false, Vector2ListField.Vector2ListRepresentationType.Polygon)]
+		[Vector2ListField("vectorlist", 10, 3,  Vector2ListField.Vector2ListRepresentationType.Polygon)]
 		internal Vector2[] VecList = new Vector2[0];
-		/*[EnumField<BepInEx.Logging.LogLevel>("enum", BepInEx.Logging.LogLevel.Warning)]
+		[EnumField<BepInEx.Logging.LogLevel>("enum", BepInEx.Logging.LogLevel.Warning)]
 		BepInEx.Logging.LogLevel Enum;
 		[ExtEnumField<AbstractCreature.AbstractObjectType>("extenum", nameof(AbstractCreature.AbstractObjectType.AttachedBee), new[] { nameof(AbstractCreature.AbstractObjectType.AttachedBee), nameof(AbstractCreature.AbstractObjectType.BubbleGrass) })]
-		AbstractCreature.AbstractObjectType ExtEnum = AbstractCreature.AbstractObjectType.AttachedBee;*/
+		AbstractCreature.AbstractObjectType ExtEnum = AbstractCreature.AbstractObjectType.AttachedBee;
 
 		public OneOfAll(PlacedObject owner) : base(owner, null)
 		{

--- a/Pom/Examples.cs
+++ b/Pom/Examples.cs
@@ -12,9 +12,9 @@ public static class Examples
 {
 	internal class OneOfAll : ManagedData
 	{
-		[ColorField("color", 1, 1, 1, 1, ManagedFieldWithPanel.ControlType.button, "color")]
+		/*[ColorField("color", 1, 1, 1, 1, ManagedFieldWithPanel.ControlType.button, "color")]
 		internal Color color;
-		[IntegerField("int", 0, 10, 0)]
+		[IntegerField("int", 0, 10, 0)] // TODO: Implement IntegerField automatically within Vector2ListField?
 		internal int Int;
 		[FloatField("float", 0f, 10f, 0f)]
 		internal float Float;
@@ -25,11 +25,14 @@ public static class Examples
 		[IntVector2Field("intvector", 3, 3, IntVector2Field.IntVectorReprType.tile)]
 		internal IntVector2 IntVec;
 		[Vector2ArrayField("vectorarray", 5, false, Vector2ArrayField.Vector2ArrayRepresentationType.Chain, 10f, 10f, 20f, 20f, 20f, -20f, -20f, -20f, -20f, 20f)]
-		internal Vector2[] VecArray = new Vector2[0];
-		[EnumField<BepInEx.Logging.LogLevel>("enum", BepInEx.Logging.LogLevel.Warning)]
+		internal Vector2[] VecArray = new Vector2[0];*/
+		// TODO: Don't forget to uncomment all of this lmao
+		[Vector2ListField("vectorlist", 10, false, Vector2ListField.Vector2ListRepresentationType.Polygon)]
+		internal Vector2[] VecList = new Vector2[0];
+		/*[EnumField<BepInEx.Logging.LogLevel>("enum", BepInEx.Logging.LogLevel.Warning)]
 		BepInEx.Logging.LogLevel Enum;
 		[ExtEnumField<AbstractCreature.AbstractObjectType>("extenum", nameof(AbstractCreature.AbstractObjectType.AttachedBee), new[] { nameof(AbstractCreature.AbstractObjectType.AttachedBee), nameof(AbstractCreature.AbstractObjectType.BubbleGrass) })]
-		AbstractCreature.AbstractObjectType ExtEnum = AbstractCreature.AbstractObjectType.AttachedBee;
+		AbstractCreature.AbstractObjectType ExtEnum = AbstractCreature.AbstractObjectType.AttachedBee;*/
 
 		public OneOfAll(PlacedObject owner) : base(owner, null)
 		{
@@ -61,7 +64,7 @@ public static class Examples
 
 			new IntegerField("i1", 0, 10, 1, ManagedFieldWithPanel.ControlType.slider, "Integer Slider"),
 			new IntegerField("i2", 0, 10, 2, ManagedFieldWithPanel.ControlType.button, "Integer Button"),
-			new IntegerField("i3", 0, 10, 3, ManagedFieldWithPanel.ControlType.arrows, "Integer Arrows"),
+			new IntegerField("i3", 0, 10, 3, ManagedFieldWithPanel.ControlType.arrows, "Integer Arrows"), // TODO: Get one of these badboys in the Vector2ListField class to control node amount
 			new IntegerField("i4", 0, 10, 3, ManagedFieldWithPanel.ControlType.text, "Integer Text"),
 
 			new StringField("str1", "your text here", "String"),

--- a/Pom/Pom.Hooks.cs
+++ b/Pom/Pom.Hooks.cs
@@ -199,13 +199,21 @@ public static partial class Pom
 				Vector2 newpos)
 	{
 		orig(self, newpos);
-		if (self.parentNode is Vector2ArrayField.Vector2ArrayHandle v2ah)
+		if (self.parentNode is Vector2ArrayField.Vector2ArrayHandle v2ah) // somebody should unhardcode this check but it will NOT be me!!!! - cactus
 		{
 			Vector2[] vectors = v2ah.Data.GetValue<Vector2[]>(v2ah.Field.key)!;
 			int index = int.Parse(self.IDstring.Split('_')[1]);
 			if (index == 0) return;
 			vectors[index] = newpos;
 			v2ah.Data.SetValue(v2ah.Field.key, vectors);
+		}
+		else if (self.parentNode is Vector2ListField.Vector2ListHandle v2lh)
+		{
+			Vector2[] vectors = v2lh.Data.GetValue<Vector2[]>(v2lh.Field.key)!;
+			int index = int.Parse(self.IDstring.Split('_')[1]);
+			if (index == 0) return;
+			vectors[index] = newpos;
+			v2lh.Data.SetValue(v2lh.Field.key, vectors);
 		}
 	}
 }

--- a/Pom/Pom.Vector2ListField.cs
+++ b/Pom/Pom.Vector2ListField.cs
@@ -1,0 +1,223 @@
+﻿using DevInterface;
+using RWCustom;
+using UnityEngine;
+
+namespace Pom;
+// TODO: Solve a way to create or destroy Vector2ListHandles for the Nodes with Dev Tools Buttons
+// Written by Cactus
+public static partial class Pom
+{
+	/// <summary>
+	/// A <see cref="ManagedField"/> that stores an array of <see cref="Vector2"/>s that can be modified in size.
+	/// </summary>
+	public class Vector2ListField : ManagedField
+	{
+		/// <summary>
+		/// Chosen representation type
+		/// </summary>
+		public Vector2ListRepresentationType RepresentationType;
+		/// <summary>
+		/// Number of vector2 nodes
+		/// </summary>
+		public int NodeCount;
+		public bool IncludeParent;
+		public int Maximum;
+
+		/// <summary>
+		/// Creates a <see cref="Vector2ListField"/> and assigns the proper values that are used in the handle
+		/// </summary>
+		/// <param name="key">The key of the field that should be used in <see cref="ManagedData.GetValue{T}"/></param>
+		/// <param name="maximum">The max number of <see cref="Vector2"/>s that the field stores</param>
+		/// <param name="includeParent">Sets if the field should use the parent as the first node</param>
+		/// <param name="representationType">The type of the representation that should be created.</param>
+// TODO: Change Vector2[] nodes to be set for 4 nodes or a list, or even make it accept a min and max node count?
+// TODO: Remove includeParent?
+		public Vector2ListField(
+			string key,
+			int maximum,
+			bool includeParent,
+			Vector2ListRepresentationType representationType = Vector2ListRepresentationType.Polygon
+			) : base(
+				key,
+				ProcessNodes())
+		{
+			NodeCount = 4;
+			RepresentationType = representationType;
+			IncludeParent = includeParent;
+			Maximum = maximum;
+		}
+
+		/// <inheritdoc/>
+		public override string ToString(object value)
+		{
+			Vector2[] vectors = (Vector2[])value;
+			return string.Join("^", vectors.Select(v => $"{v.x};{v.y}").ToArray());
+		}
+		/// <inheritdoc/>
+		public override object FromString(string str)
+		{
+			List<Vector2> positions = new List<Vector2>();
+			foreach (string substring in str.Split('^'))
+			{
+				string[] split = substring.Split(';');
+				positions.Add(new Vector2(float.Parse(split[0]), float.Parse(split[1])));
+			}
+
+			return positions.ToArray();
+		}
+
+		// Make a square for the base node set
+		private static object ProcessNodes()
+		{
+			Vector2[] result =
+			{
+				new (40f, 40f),
+				new (40f, -40f),
+				new (-40f, -40f),
+				new (-40f, 40f)
+			};
+			
+			return result;
+		}
+		/// <inheritdoc/>
+		public override DevUINode MakeAditionalNodes(ManagedData managedData, ManagedRepresentation managedRepresentation)
+		{
+			return new Vector2ListHandle(this, managedData, managedRepresentation);
+		}
+		/// <summary>
+		/// How the handle should look like
+		/// </summary>
+		public enum Vector2ListRepresentationType
+		{
+			/// <summary>
+			/// Handle is an open-ended chain
+			/// </summary>
+			Chain,
+			/// <summary>
+			/// Handle is a polygon (start and end connected)
+			/// </summary>
+			Polygon
+		}
+		/// <summary>
+		/// Special handle for vector2listfield
+		/// </summary>
+// TODO: Solve a way to create or destroy Vector2ListHandles for the Nodes with Dev Tools Buttons
+		public class Vector2ListHandle : PositionedDevUINode
+		{
+			/// <summary>
+			/// Associated field
+			/// </summary>
+			public Vector2ListField Field;
+			/// <summary>
+			/// Associated placedobject's data
+			/// </summary>
+			public ManagedData Data;
+			/// <summary>
+			/// First node
+			/// </summary>
+			public PositionedDevUINode First;
+			/// <summary>
+			/// List of line subnode indices
+			/// </summary>
+			public List<int> Lines = new List<int>();
+
+			/// <param name="field">Field definition</param>
+			/// <param name="data">Associated placedobject's data</param>
+			/// <param name="representation">Associated placedobject's representation</param>
+			public Vector2ListHandle(
+				Vector2ListField field,
+				ManagedData data,
+				ManagedRepresentation representation) : base(
+					representation.owner,
+					field.key,
+					representation,
+					(data.GetValue<Vector2[]>(field.key) ?? new Vector2[] { default })[0])
+			{
+				Field = field;
+				
+				Data = data;
+				bool includeParent = Field.IncludeParent;
+				if (includeParent)
+				{
+					First = (parentNode as PositionedDevUINode)!;
+				}
+				else
+				{
+					First = new Handle(owner, field.key + "_0", this, Data.GetValue<Vector2[]>(field.key)![0]);
+					subNodes.Add(First);
+				}
+
+				for (int i = 1; i < field.NodeCount; i++)
+				{
+					int currentLine = fSprites.Count;
+					PositionedDevUINode next = new Handle(owner, field.key + "_" + i, this, Data.GetValue<Vector2[]>(field.key)![i]);
+					subNodes.Add(next);
+					fSprites.Add(new FSprite("pixel"));
+					owner.placedObjectsContainer.AddChild(fSprites[currentLine]);
+					fSprites[currentLine].anchorY = 0;
+					Lines.Add(currentLine);
+				}
+
+				if (Field.RepresentationType == Vector2ListRepresentationType.Polygon)
+				{
+					int currLine = fSprites.Count;
+					fSprites.Add(new FSprite("pixel"));
+					owner.placedObjectsContainer.AddChild(fSprites[currLine]);
+					fSprites[currLine].anchorY = 0;
+					Lines.Add(currLine);
+				}
+			}
+			/// <inheritdoc/>
+			// TODO: Figure out how to set control node to (0, 0) or other value if IncludeParent is false
+			public override void Move(Vector2 newPos)
+			{
+				First.Move(newPos);
+				Vector2[] vArr = Data.GetValue<Vector2[]>(Field.key)!;
+				vArr[0] = Field.IncludeParent ? new Vector2(0, 0) : newPos;
+				Data.SetValue(Field.key, vArr);
+				base.Move(newPos);
+			}
+			/// <inheritdoc/>
+			public override void Refresh()
+			{
+				base.Refresh();
+				PositionedDevUINode start = First;
+				int offset = Field.IncludeParent ? 0 : 1;
+				for (int i = offset; i < subNodes.Count; i++)
+				{
+					if (!(subNodes[i] is PositionedDevUINode end))
+					{
+						throw new NullReferenceException("end node cannot be null!!");
+					}
+
+					int lineIndex = Lines[i - offset];
+					MoveSprite(lineIndex, start.absPos);
+					FSprite lineSprite = fSprites[lineIndex];
+					lineSprite.scaleY = (end.absPos - start.absPos).magnitude;
+					lineSprite.rotation = Custom.VecToDeg(end.absPos - start.absPos);
+					start = end;
+				}
+
+				if (Field.RepresentationType == Vector2ListRepresentationType.Polygon)
+				{
+					int lastIndex = Lines[Lines.Count - 1];
+					MoveSprite(lastIndex, start.absPos);
+					FSprite lineSprite = fSprites[lastIndex];
+					lineSprite.scaleY = (start.absPos - First.absPos).magnitude;
+					lineSprite.rotation = Custom.VecToDeg(First.absPos - start.absPos);
+				}
+			}
+		}
+		// Note to self: This makes an array of vector2s out of every two floats in the given array!
+		// Don't even need the other make nodes i think... since you can always add or subtract a node.
+		private static Vector2[] MakeVectors(float[] floats)
+		{
+			Vector2[] res = new Vector2[floats.Length / 2];
+			for (int i = 0; i < res.Length; i++)
+			{
+				res[i] = new(floats[i * 2], floats[i * 2 + 1]);
+			}
+			return res;
+		}
+	}
+}

--- a/Pom/Pom.Vector2ListField.cs
+++ b/Pom/Pom.Vector2ListField.cs
@@ -1,6 +1,7 @@
 ﻿using DevInterface;
 using RWCustom;
 using UnityEngine;
+using Random = UnityEngine.Random;
 
 namespace Pom;
 
@@ -105,10 +106,34 @@ public static partial class Pom
 
 				
 				Vector2[] copy = new Vector2[oldLength + 1];
+				Vector2 newPos = new Vector2(Random.value * 500f * (Random.value - 0.5f), Random.value * 500f * (Random.value - 0.5f));
+				copy[copy.Length - 1] = newPos;
+				
 				Array.Copy(data.GetValue<Vector2[]>(key), copy, oldLength);
 				
 				data.SetValue(key, copy);
 				
+				// Adds the handle to remove the node
+				List<DevInterface.DevUINode> uiList = node.parentNode.parentNode.subNodes;
+
+				for (int i = 0; i < uiList.Count; i++)
+				{
+					if (uiList[i].IDstring.Equals(this.key)) // Gets this current field
+					{
+						this.NodeCount = data.GetValue<Vector2[]>(this.key).Length;
+						
+						for (int j = 0; j < uiList[i].subNodes.Count; j++)
+						{
+							uiList[i].subNodes[j].ClearSprites();
+						}
+						for (int j = 0; j < uiList[i].fSprites.Count; j++)
+						{
+							uiList[i].fSprites[j].container.RemoveChild(uiList[i].fSprites[j]);
+						}
+						uiList[i] = new Vector2ListHandle(this, data, (uiList[i] as Vector2ListHandle).rep);
+						break;
+					}
+				}
 			}
 		}
 		
@@ -129,6 +154,28 @@ public static partial class Pom
 				Array.Copy(data.GetValue<Vector2[]>(key), copy, oldLength - 2);
 				
 				data.SetValue(key, copy);
+				
+				// Reloads the handle to remove the node
+				List<DevInterface.DevUINode> uiList = node.parentNode.parentNode.subNodes;
+
+				for (int i = 0; i < uiList.Count; i++)
+				{
+					if (uiList[i].IDstring.Equals(this.key)) // Gets this current field
+					{
+						this.NodeCount = data.GetValue<Vector2[]>(this.key).Length;
+						//
+						for (int j = 0; j < uiList[i].subNodes.Count; j++)
+						{
+							uiList[i].subNodes[j].ClearSprites();
+						}
+						for (int j = 0; j < uiList[i].fSprites.Count; j++)
+						{
+							uiList[i].fSprites[j].container.RemoveChild(uiList[i].fSprites[j]);
+						}
+						uiList[i] = new Vector2ListHandle(this, data, (uiList[i] as Vector2ListHandle).rep);
+						break;
+					}
+				}
 			}
 		}
 		
@@ -171,6 +218,8 @@ public static partial class Pom
 			/// First node
 			/// </summary>
 			public PositionedDevUINode First;
+
+			internal ManagedRepresentation rep;
 			/// <summary>
 			/// List of line subnode indices
 			/// </summary>
@@ -189,7 +238,7 @@ public static partial class Pom
 					(data.GetValue<Vector2[]>(field.key) ?? new Vector2[] { default })[0])
 			{
 				Field = field;
-				
+				rep = representation;
 				Data = data;
 				bool includeParent = Field.IncludeParent;
 				if (includeParent)

--- a/Pom/Pom.Vector2ListField.cs
+++ b/Pom/Pom.Vector2ListField.cs
@@ -3,7 +3,7 @@ using RWCustom;
 using UnityEngine;
 
 namespace Pom;
-// TODO: Solve a way to create or destroy Vector2ListHandles for the Nodes with Dev Tools Buttons
+
 // Written by Cactus
 public static partial class Pom
 {
@@ -32,13 +32,12 @@ public static partial class Pom
 		/// <param name="maximum">The max number of <see cref="Vector2"/>s that the field stores</param>
 		/// <param name="includeParent">Sets if the field should use the parent as the first node</param>
 		/// <param name="representationType">The type of the representation that should be created.</param>
-// TODO: Change Vector2[] nodes to be set for 4 nodes or a list, or even make it accept a min and max node count?
 // TODO: Remove includeParent?
+// TODO: Fix first node's position influencing other node positions on save
 		public Vector2ListField(
 			string key,
 			int maximum,
 			int minimum,
-			bool includeParent,
 			Vector2ListRepresentationType representationType = Vector2ListRepresentationType.Polygon
 			) : base(
 				key,
@@ -46,7 +45,7 @@ public static partial class Pom
 		{
 			NodeCount = 3;
 			RepresentationType = representationType;
-			IncludeParent = includeParent;
+			IncludeParent = true;
 			Maximum = maximum;
 			Minimum = minimum;
 		}
@@ -58,8 +57,6 @@ public static partial class Pom
 			// First toString position is from the position of the int handle
 			// Separates the vectors by "^", Separates the vector components by ";" 
 			Vector2[] vectors = (Vector2[])value;
-			foreach (Vector2 vector in vectors)
-				Debug.Log(vector);
 			return string.Join("^", vectors.Select(v => $"{v.x};{v.y}").ToArray());
 		}
 		/// <inheritdoc/>
@@ -68,7 +65,6 @@ public static partial class Pom
 			List<Vector2> positions = new List<Vector2>();
 			foreach (string substring in str.Split('^'))
 			{
-				Debug.Log(substring);
 				string[] split = substring.Split(';');
 				positions.Add(new Vector2(float.Parse(split[0]), float.Parse(split[1])));
 			}
@@ -81,7 +77,7 @@ public static partial class Pom
 			ManagedControlPanel panel,
 			float sizeOfDisplayname)
 		{
-			return new ManagedArrowSelector(this, managedData, panel, 20f);
+			return new ManagedArrowSelector(this, managedData, panel, 72f);
 		}
 		
 		public override string? DisplayValueForNode(
@@ -112,8 +108,7 @@ public static partial class Pom
 				Array.Copy(data.GetValue<Vector2[]>(key), copy, oldLength);
 				
 				data.SetValue(key, copy);
-				Debug.Log(data.GetValue<Vector2[]>(key).Length);
-				Debug.Log(data.ToString());
+				
 			}
 		}
 		
@@ -134,8 +129,6 @@ public static partial class Pom
 				Array.Copy(data.GetValue<Vector2[]>(key), copy, oldLength - 2);
 				
 				data.SetValue(key, copy);
-				Debug.Log(data.GetValue<Vector2[]>(key).Length);
-				Debug.Log(data.ToString());
 			}
 		}
 		
@@ -147,6 +140,7 @@ public static partial class Pom
 		/// <inheritdoc/>
 		public override DevUINode MakeAditionalNodes(ManagedData managedData, ManagedRepresentation managedRepresentation)
 		{
+			this.NodeCount = managedData.GetValue<Vector2[]>(this.key).Length;
 			return new Vector2ListHandle(this, managedData, managedRepresentation);
 		}
 		/// <summary>
@@ -194,7 +188,6 @@ public static partial class Pom
 					representation,
 					(data.GetValue<Vector2[]>(field.key) ?? new Vector2[] { default })[0])
 			{
-				Debug.Log("Making field handle!!!");
 				Field = field;
 				
 				Data = data;
@@ -238,7 +231,6 @@ public static partial class Pom
 				Vector2[] vArr = Data.GetValue<Vector2[]>(Field.key)!;
 				// Sets initial value to 0,0 if include parent is false
 				vArr[0] = Field.IncludeParent ? new Vector2(0, 0) : newPos;
-				Debug.Log("Movement to here: " + vArr.ToString());
 				Data.SetValue(Field.key, vArr);
 				base.Move(newPos);
 			}
@@ -284,7 +276,6 @@ public static partial class Pom
 			}
 			return res;
 		}
-		// TODO: Figure out how to make this NOT an invalid data type
 		public override float SizeOfLargestDisplayValue()
 		{
 			return HUD.DialogBox.meanCharWidth * ((Mathf.Max(Mathf.Abs(0), Mathf.Abs(Maximum))).ToString().Length + 2);


### PR DESCRIPTION
Add a new POM Object type, the VectorList. This is similar to the VectorArray, but the leditor using it can control the amount of nodes via dev tools. This allows for things like controllable node amounts for large decals or lights.

The controls are the VectorList in the image, and the number with the integer controls is the node amount.
![image](https://github.com/user-attachments/assets/12cea38d-ec9b-4ab2-aef5-a7762aefd383)
